### PR TITLE
Get configured networks function added

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,35 @@ See [here](./PLUGIN_USAGE.MD#cordova.plugins.hotspot) for complete API reference
 For Ionic Guidance see [here](https://github.com/hypery2k/cordova-hotspot-plugin/wiki/Ionic-usage).
 You need to make sure that you have the right [Android permissions](https://github.com/hypery2k/cordova-hotspot-plugin/wiki/Android-Configuration).
 
+# Custom Changes
+
+## getConfiguredNetworks()
+This method was added to expose the configured networks to JS, the full docs for this method is [here](https://developer.android.com/reference/android/net/wifi/WifiManager.html#getConfiguredNetworks()
+)
+
+### How to use
+```js
+    // Plugin instance
+    const hotSpotPlugin = window['cordova'].plugins.hotspot;
+
+    hotSpotPlugin.getConfiguredNetworks((networksList) => {
+        console.log(networksList);
+        /**
+           [
+               {
+                   SSID: string
+                   hiddenSSID: boolean
+                   networkId: number
+                   preSharedKey: string
+                   status: string
+                }
+           ]
+        */
+    }, (err) => {
+        console.log(err);
+    });
+```
+
 ## Dev
 
 ### To run the tests

--- a/www/HotSpotPlugin.js
+++ b/www/HotSpotPlugin.js
@@ -461,6 +461,19 @@ HotSpotPlugin.prototype = {
             successCB(false);
         }, 'HotSpotPlugin', 'isWifiDirectSupported', []);
     },
+     /**
+     * Get configured networks
+     *
+     * @param {getConfiguredNetworksCallback} successCB
+     *      A callback function to be called when networks exists
+     * @param {errorCallback} errorCB
+     *      An error callback
+     */
+    getConfiguredNetworks: function (successCB, errorCB) {
+        cordova.exec(successCB, function (err) {
+            errorCB(err);
+        }, 'HotSpotPlugin', 'getConfiguredNetworks', []);
+    },
     /**
      * A callback function to be called when scan is started
      *


### PR DESCRIPTION
For https://github.com/StarfishCo/cordova-hotspot-plugin/issues/5

## Overview
Changes to get configured networks previously merged to master

## Changes
The function `getConfiguredNetworks` was exposed to be able to see the previous connected networks using javascript