### PR TITLE
[Build 37 Hotfix] More robust captive portal detection

### DIFF
--- a/src/android/com/mady/wifi/api/WifiHotSpots.java
+++ b/src/android/com/mady/wifi/api/WifiHotSpots.java
@@ -253,7 +253,7 @@ public class WifiHotSpots {
     /**
      * This function works under the assumption that we have already determined that we are connected to a valid network.
      * Determines if current connection is a captive portal by checking if we can access Apple's captive portal detection
-     * page. If we receive 'Success' in the request's response body, there is not
+     * page. If we receive 'Success' in the request's response body, there is no captive portal
      */
     public boolean isCaptivePortalConnection() {
         InputStream stream = null;

--- a/src/android/com/mady/wifi/api/WifiHotSpots.java
+++ b/src/android/com/mady/wifi/api/WifiHotSpots.java
@@ -16,7 +16,6 @@ import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.util.Log;
-
 import java.io.*;
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
@@ -25,6 +24,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
+
 
 public class WifiHotSpots {
     /**
@@ -251,28 +251,41 @@ public class WifiHotSpots {
     }
 
     /**
-     * Determines if current connection is a captive portal by checking if we get a 204 response
-     * from google. If we do not, we can assume this is do to a captive portal instead returning a 200 response.
-     * Logic taken from https://stackoverflow.com/questions/13958614/how-to-check-for-unrestricted-internet-access-captive-portal-detection
+     * This function works under the assumption that we have already determined that we are connected to a valid network.
+     * Determines if current connection is a captive portal by checking if we can access Apple's captive portal detection
+     * page. If we receive 'Success' in the request's response body, there is not
      */
     public boolean isCaptivePortalConnection() {
+        InputStream stream = null;
+        BufferedReader br = null;
+        InputStreamReader sr = null;
         HttpURLConnection urlConnection = null;
+        String responseBody = null;
+        String testUrl = "http://captive.apple.com/hotspot-detect.html";
         try {
-            URL url = new URL("http://clients3.google.com/generate_204");
+            URL url = new URL(testUrl);
             urlConnection = (HttpURLConnection) url.openConnection();
             urlConnection.setInstanceFollowRedirects(false);
             urlConnection.setConnectTimeout(10000);
             urlConnection.setReadTimeout(10000);
             urlConnection.setUseCaches(false);
-            urlConnection.getInputStream();
-            // We got a valid response, but not from the real google
-            return urlConnection.getResponseCode() != 204;
+
+            stream = urlConnection.getInputStream(); // input stream is null for non 200 responses
+            if (stream != null) sr = new InputStreamReader(stream);
+            if (sr != null) br = new BufferedReader(sr);
+            if (br != null) responseBody = br.readLine(); // Success is in first line of input stream
+
+            // if no response body or it doesn't contain "Success", the request was probably blocked by a captive portal
+            if (responseBody == null || !responseBody.contains("Success")) return true;
+
+            Log.d("RAVEN", testUrl + " returned 'Success' in its response body. Not a captive portal.");
         } catch (IOException e) {
-            Log.d("RAVEN", "Captive portal check - probably not a portal: exception " + e.toString());
+            Log.d("RAVEN", "Captive portal check failed for " + testUrl + " - probably not a portal: exception " + e.getMessage());
             return false;
         } finally {
             if (urlConnection != null) {
                 urlConnection.disconnect();
+                urlConnection = null;
             }
         }
     }

--- a/src/android/com/mady/wifi/api/WifiHotSpots.java
+++ b/src/android/com/mady/wifi/api/WifiHotSpots.java
@@ -281,13 +281,13 @@ public class WifiHotSpots {
             Log.d("RAVEN", testUrl + " returned 'Success' in its response body. Not a captive portal.");
         } catch (IOException e) {
             Log.d("RAVEN", "Captive portal check failed for " + testUrl + " - probably not a portal: exception " + e.getMessage());
-            return false;
         } finally {
             if (urlConnection != null) {
                 urlConnection.disconnect();
                 urlConnection = null;
             }
         }
+        return false;
     }
 
     private int getExistingNetworkId(String SSID) {

--- a/src/android/de/martinreinhardt/cordova/plugins/hotspot/HotSpotPlugin.java
+++ b/src/android/de/martinreinhardt/cordova/plugins/hotspot/HotSpotPlugin.java
@@ -29,17 +29,24 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.net.Uri;
-import android.net.wifi.WifiManager;
 import android.net.wifi.ScanResult;
 import android.net.wifi.WifiConfiguration;
 import android.net.wifi.WifiInfo;
+import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.provider.Settings;
 import android.util.Log;
 import com.mady.wifi.api.WifiAddresses;
 import com.mady.wifi.api.WifiHotSpots;
 import com.mady.wifi.api.WifiStatus;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.PermissionHelper;
@@ -47,14 +54,7 @@ import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 
-import java.lang.reflect.Method;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.List;
 
 public class HotSpotPlugin extends CordovaPlugin {
 
@@ -1014,7 +1014,7 @@ public class HotSpotPlugin extends CordovaPlugin {
       Log.d("RAVEN", "Is captive portal - " + isCaptivePortal);
       callback.success(result);
     } catch (JSONException e) {
-      Log.d("RAVEN", "ERROR - failed to determine if network had a captive portal. Assuming that it doesn't.");
+      Log.d("RAVEN", "ERROR - failed to determine if network had a captive portal. Assuming that it doesn't. " + e.getMessage());
       JSONObject result = new JSONObject();
       result.put("isCaptivePortal", false);
       callback.success(result);
@@ -1135,6 +1135,7 @@ public class HotSpotPlugin extends CordovaPlugin {
    */
   private void threadhelper(final HotspotFunction f, final String rawArgs, final CallbackContext callbackContext) {
     cordova.getThreadPool().execute(new Runnable() {
+      @Override
       public void run() {
         try {
           JSONArray args = new JSONArray(rawArgs);


### PR DESCRIPTION
For #693

- Enhances captive portal detection by using Apple's implementation of checking `http://captive.apple.com/hotspot-detect.html` for "Success" in the response body.
- Old implementation didn't work at Starbucks because the testUrl `http://clients3.google.com/generate_204` was always generating a 204 response code due to their network configuration. I believe this was in part due to their captive portal having an SSL certificate at `https://wifi.starbucks.com`
- Verified that the new implementation works with the test router at the office and at Starbucks, Wendy's, and McDonald's