### PR TITLE
Add function to check for connection over TCP too

### DIFF
--- a/src/android/com/mady/wifi/api/WifiStatus.java
+++ b/src/android/com/mady/wifi/api/WifiStatus.java
@@ -310,7 +310,7 @@ public class WifiStatus {
         // Any Open port on other machine
         // openPort =  22 - ssh, 80 or 443 - webserver, 25 - mailserver etc.
         try {
-            Log.d("RAVEN", "Trying TCP connection to " + addr + " over port " + openPort.toString());
+            Log.d("RAVEN", "Trying TCP connection to " + addr + " over port " + String.valueOf(openPort));
             try (Socket soc = new Socket()) {
                 // throws IOException if connection cannot be established on port
                 soc.connect(new InetSocketAddress(addr, openPort), timeOutMillis);

--- a/src/android/com/mady/wifi/api/WifiStatus.java
+++ b/src/android/com/mady/wifi/api/WifiStatus.java
@@ -26,10 +26,8 @@ import android.util.Log;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.net.UnknownHostException;
 import java.util.List;
 
 

--- a/src/android/com/mady/wifi/api/WifiStatus.java
+++ b/src/android/com/mady/wifi/api/WifiStatus.java
@@ -275,6 +275,7 @@ public class WifiStatus {
      */
     public boolean pingCmd(String addr) {
         try {
+            Log.d("RAVEN", "Pinging " + addr);
             String ping = "ping  -c 1 -W 3 " + addr;
             Runtime run = Runtime.getRuntime();
             Process pro = run.exec(ping);
@@ -290,9 +291,8 @@ public class WifiStatus {
         } catch (IOException e) {
             Log.d("RAVEN", "ICMP ping error - " + e.getMessage());
         }
-        Log.d("RAVEN", "ICMP ping to " + addr + " failed, trying TCP connection over port 443");
+        Log.d("RAVEN", "ICMP ping to " + addr + " failed");
         if (isReachable(addr, 443, 5000)) return true;
-        Log.d("RAVEN", "TCP connection to  " + addr + " failed, trying TCP connection over port 80");
         return isReachable(addr, 80, 5000);
     }
 
@@ -310,6 +310,7 @@ public class WifiStatus {
         // Any Open port on other machine
         // openPort =  22 - ssh, 80 or 443 - webserver, 25 - mailserver etc.
         try {
+            Log.d("RAVEN", "Trying TCP connection to " + addr + " over port " + openPort.toString());
             try (Socket soc = new Socket()) {
                 // throws IOException if connection cannot be established on port
                 soc.connect(new InetSocketAddress(addr, openPort), timeOutMillis);


### PR DESCRIPTION
For https://github.com/StarfishCo/raven-scanner-app/issues/1895

# Overview

It is a common firewall setting to disable ICMP echo requests/replies. This results in customers with these firewall settings set to have an unreliable internet connection due to us using ICMP pings to verify if users' scanners are currently connected to the internet.

We will still ICMP ping so that this reverse compatible and not potentially affect users' connections that were fine with these ICMP pings. We will instead add additional TCP connection checks on ports 443 and 80 if the ICMP ping failed.

## Changes
- If ICMP ping fails, check for valid TCP connection on ports 443 and 80

Implementation was taken from https://stackoverflow.com/a/34228756/13173970