### PR TITLE
Remove ACCESS_FINE_LOCATION permission

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,6 @@
       <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
       <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
       <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
-      <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
       <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
       <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
       <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>

--- a/src/android/de/martinreinhardt/cordova/plugins/hotspot/HotSpotPlugin.java
+++ b/src/android/de/martinreinhardt/cordova/plugins/hotspot/HotSpotPlugin.java
@@ -66,8 +66,6 @@ public class HotSpotPlugin extends CordovaPlugin {
    */
   private static final String LOG_TAG = "HotSpotPlugin";
 
-  public static String[] permissions = { Manifest.permission.ACCESS_FINE_LOCATION };
-
   public static final int REQUEST_CODE_SETTINGS_INTENT = 400;
 
   private CallbackContext callback;
@@ -78,15 +76,6 @@ public class HotSpotPlugin extends CordovaPlugin {
 
   private interface HotspotFunction {
     void run(JSONArray args, CallbackContext callback) throws Exception;
-  }
-
-  public boolean hasPermissions() {
-    for (String p : permissions) {
-      if (!PermissionHelper.hasPermission(this, p)) {
-        return false;
-      }
-    }
-    return true;
   }
 
   /**
@@ -107,47 +96,11 @@ public class HotSpotPlugin extends CordovaPlugin {
     this.callback = callback;
     this.action = action;
     this.rawArgs = rawArgs;
-    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP + 1) {
-      Class systemClass = Settings.System.class;
-      try {
-        Method canWriteMethod = systemClass.getDeclaredMethod("canWrite", Context.class);
-        boolean retVal = (Boolean) canWriteMethod.invoke(null, this.cordova.getActivity());
-        Log.d(LOG_TAG, "Can Write Settings: " + retVal);
-        if (!retVal && !action.equals("requestWriteSettings") && !action.equals("getWriteSettings")) {
-          // With Android 6.0+/API level>= 23, user can turn on/off permissions as
-          // necessary.
-          // Permissions are explicitely granted during the app runtime.
-          if (Build.VERSION.SDK_INT < 23) {
-            // can't write Settings
-            callback.error("write settings: false");
-            return false;
-          }
-        }
-        this.writeSettings = retVal;
-      } catch (Exception ignored) {
-        Log.e(LOG_TAG, "Could not perform permission check");
-        this.callback.sendPluginResult(new PluginResult(PluginResult.Status.ILLEGAL_ACCESS_EXCEPTION));
-      }
-    }
-    if (!this.hasPermissions()) {
-      PermissionHelper.requestPermissions(this, 0, HotSpotPlugin.permissions);
-      return true;
-    } else {
-      // pre Android 6 behaviour
-      return executeInternal(action, rawArgs, callback);
-    }
+    
+    // Since our scanners are on version 4, no need to check for GPS permission. It does not become a requirement
+    // for WiFi scanning until Android version 6.
+    return executeInternal(action, rawArgs, callback);
     // Returning false results in a "MethodNotFound" error.
-  }
-
-  public void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults)
-      throws JSONException {
-    for (int r : grantResults) {
-      if (r == PackageManager.PERMISSION_DENIED) {
-        this.callback.sendPluginResult(new PluginResult(PluginResult.Status.ILLEGAL_ACCESS_EXCEPTION));
-        return;
-      }
-    }
-    executeInternal(this.action, this.rawArgs, this.callback);
   }
 
   private void requestWriteSettings(CallbackContext callback) {
@@ -165,9 +118,8 @@ public class HotSpotPlugin extends CordovaPlugin {
   }
 
   private boolean executeInternal(String action, String rawArgs, CallbackContext callback) {
-    Log.i(LOG_TAG, "Running executeInternal() ");
-    Log.i(LOG_TAG, "     action: " + action);
-    Log.i(LOG_TAG, "     rawArgs: " + rawArgs);
+    Log.i(LOG_TAG, "Running executeInternal(), action: " + action + ", rawArgs: " + rawArgs);
+
     if ("requestWriteSettings".equals(action)) {
       threadhelper(new HotspotFunction() {
         @Override


### PR DESCRIPTION
For https://github.com/StarfishCo/raven-scanner-app/issues/1518

**Code reviewers** - please check these links to double-check my reasoning that this permission is fine to remove 🙏  I have not run into any issues with testing this

We don't need `ACCESS_FINE_LOCATION` permission (GPS permission) because this didn't become a requirement for network scanning until Android version 6. All of our scanners are on an Android version 4 variant. See google thread regarding permission dependency added in Android version 6 - https://issuetracker.google.com/issues/37060483

You can also see here that this `ACCES_FINE_LOCATION` permission request was added in response to a ticket for Android version 6 compatibility - https://github.com/hypery2k/cordova-hotspot-plugin/issues/30

Also, removed portion that is checking for permission because this implementation isn't needed for permissions in Android version 6. In version 6, permissions aren't granted at run-time so this would do nothing for our scanners - https://developer.android.com/training/permissions/requesting#perm-check