### PR TITLE
Return mac address on connection info object

### DIFF
--- a/src/android/de/martinreinhardt/cordova/plugins/hotspot/HotSpotPlugin.java
+++ b/src/android/de/martinreinhardt/cordova/plugins/hotspot/HotSpotPlugin.java
@@ -589,6 +589,7 @@ public class HotSpotPlugin extends CordovaPlugin {
       result.put("linkSpeed", wifiInfo.getLinkSpeed());
       result.put("IPAddress", intToInetAddress(wifiInfo.getIpAddress())).toString();
       result.put("networkID", wifiInfo.getNetworkId());
+      result.put("MACAddress", wifiInfo.getMacAddress());
       callback.success(result);
     } catch (JSONException e) {
       Log.e(LOG_TAG, "Error during reading connection info.", e);


### PR DESCRIPTION
For https://github.com/StarfishCo/raven-scanner-app/issues/1929

## Overview 
The scanner is showing the network BSSID as MAC Address instead of the real mac address

## Changes

- Return mac address on connection info object