### PR TITLE
Ping raven api instead of google

### DIFF
--- a/src/android/com/mady/wifi/api/WifiStatus.java
+++ b/src/android/com/mady/wifi/api/WifiStatus.java
@@ -256,7 +256,7 @@ public class WifiStatus {
      * @return true if device connect to Internet or return false if not
      */
     public boolean isConnectedToInternet() {
-        return pingCmd("www.google.com");
+        return pingCmd("api.raven.com");
     }
 
     /**

--- a/src/android/com/mady/wifi/api/WifiStatus.java
+++ b/src/android/com/mady/wifi/api/WifiStatus.java
@@ -262,7 +262,7 @@ public class WifiStatus {
             NetworkInfo info = connectivity.getActiveNetworkInfo();
             if (info != null) {
                 if (info.isConnected()) {
-                    return pingCmd("www.google.com");
+                    return pingCmd("api.raven.com");
                 }
             }
         }


### PR DESCRIPTION
For https://github.com/StarfishCo/raven-scanner-app/issues/1983

## Overview
The ping to google is being blocked in China

## Changes
- Ping to `api.raven.com`